### PR TITLE
根据注册信息一键下单

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -37,6 +37,8 @@
              </a>
                 <h3>健人速食</h3> <!-- 标题 -->
                 <p>让你轻松解决健身期间的饮食问题</p> <!-- 内文 -->
+                <br>
+                <p class="lead"> <a class="btn btn-lg btn-danger" href="/products"> 一键解决烦恼</a></p>
              </div>
            </div>
 
@@ -46,6 +48,8 @@
              <div class="carousel-caption">
                 <h3>健康配比</h3>
                 <p>营养学数据做支撑，按性别配置一周健康午餐</p>
+                <br>
+                <p class="lead"> <a class="btn btn-lg btn-danger" href="/products"> 一键解决烦恼</a></p>
              </div>
             </a>
            </div>
@@ -55,6 +59,8 @@
              <div class="carousel-caption">
                 <h3>一键下单</h3>
                 <p>点餐也纠结吃什么？没关系！只需一键下单，轻松解决！</p>
+                <br>
+                <p class="lead"> <a class="btn btn-lg btn-danger" href="/products"> 一键解决烦恼</a></p>
              </div>
           </a>
            </div>


### PR DESCRIPTION
1. 新增一键下单按钮（会跟着首页轮换的图跑掉，你到时候动主页的时候看看怎么放好）
2.一键下单按钮能根据当前账户的性别和是否健身信息自动跳转不同类别商品
3. 顺手重新修复了product list 显示类型名称失败的bug（上次修复过不知道为什么merge之后又消失了）